### PR TITLE
-Added AsyncResponseTimeout to add support for Long Polling

### DIFF
--- a/Camunda.Api.Client/ExternalTask/FetchExternalTasks.cs
+++ b/Camunda.Api.Client/ExternalTask/FetchExternalTasks.cs
@@ -20,6 +20,11 @@ namespace Camunda.Api.Client.ExternalTask
         public bool UsePriority;
 
         /// <summary>
+        /// Response timeout for long polling
+        /// </summary>
+        public long AsyncResponseTimeout;
+
+        /// <summary>
         /// Array of topic objects for which external tasks should be fetched. The returned tasks may be arbitrarily distributed among these topics.
         /// </summary>
         public List<FetchExternalTaskTopic> Topics;

--- a/Camunda.Api.Client/ExternalTask/FetchExternalTasks.cs
+++ b/Camunda.Api.Client/ExternalTask/FetchExternalTasks.cs
@@ -20,7 +20,7 @@ namespace Camunda.Api.Client.ExternalTask
         public bool UsePriority;
 
         /// <summary>
-        /// Response timeout for long polling
+        /// The Long Polling timeout in milliseconds. The value cannot be set larger than 1.800.000 milliseconds (corresponds to 30 minutes).
         /// </summary>
         public long AsyncResponseTimeout;
 


### PR DESCRIPTION
Added "asyncResponseTimeout" to FetchExternalTasks to add support for Long Polling

Note: This is my first ever pull request, feel free to message me if I did anything wrong / if I broke any best practices