### PR TITLE
Chainable ErrorMessageHandler

### DIFF
--- a/Camunda.Api.Client/Camunda.Api.Client.csproj
+++ b/Camunda.Api.Client/Camunda.Api.Client.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>    
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.4.3</Version>
+    <Version>2.5.0-prerelease01</Version>
     <Product>Camunda REST API Client</Product>
     <Title>Camunda REST API Client</Title>
     <Authors>Jan Lucansky</Authors>

--- a/Camunda.Api.Client/ErrorMessageHandler.cs
+++ b/Camunda.Api.Client/ErrorMessageHandler.cs
@@ -6,8 +6,16 @@ using System.Threading.Tasks;
 
 namespace Camunda.Api.Client
 {
-    public class ErrorMessageHandler : HttpClientHandler
+    public class ErrorMessageHandler : DelegatingHandler
     {
+        public ErrorMessageHandler(HttpMessageHandler innerHandler) : base(innerHandler)
+        {
+        }
+
+        public ErrorMessageHandler() : base(new HttpClientHandler())
+        {
+        }
+
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var response = await base.SendAsync(request, cancellationToken);


### PR DESCRIPTION
Changed ErrorMessageHandler to accept an optional inner HttpMessageHandler, so it can be used as part of a chain of other message handlers.

We have a custom HttpMessageHandler that does the actual request, but I still like to use the exception handling as provided by ErrorMessageHandler.

Doesn't break anything, as the default constructor passes a HttpClientHandler as inner handler, which results in the same behavior as before.