### PR TITLE
Added feature to complete user task and fetch variables

### DIFF
--- a/Camunda.Api.Client/UserTask/CompleteTask.cs
+++ b/Camunda.Api.Client/UserTask/CompleteTask.cs
@@ -2,17 +2,8 @@
 
 namespace Camunda.Api.Client.UserTask
 {
-    public class CompleteTask
+    public class CompleteTask: CompleteTaskBase
     {
-        /// <summary>
-        /// Object containing variable key-value pairs.
-        /// </summary>
-        public Dictionary<string, VariableValue> Variables = new Dictionary<string, VariableValue>();
-
-        public CompleteTask SetVariable(string name, object value)
-        {
-            Variables = (Variables ?? new Dictionary<string, VariableValue>()).Set(name, value);
-            return this;
-        }
+        public override bool WithVariablesInReturn => false;
     }
 }

--- a/Camunda.Api.Client/UserTask/CompleteTask.cs
+++ b/Camunda.Api.Client/UserTask/CompleteTask.cs
@@ -5,6 +5,6 @@
         /// <summary>
         /// Variables will return after completing the task
         /// </summary>
-        protected override bool WithVariablesInReturn => false;
+        public override bool WithVariablesInReturn => false;
     }
 }

--- a/Camunda.Api.Client/UserTask/CompleteTask.cs
+++ b/Camunda.Api.Client/UserTask/CompleteTask.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections.Generic;
-
-namespace Camunda.Api.Client.UserTask
+﻿namespace Camunda.Api.Client.UserTask
 {
-    public class CompleteTask: CompleteTaskBase
+    public class CompleteTask : CompleteTaskBase
     {
-        public override bool WithVariablesInReturn => false;
+        /// <summary>
+        /// Variables will return after completing the task
+        /// </summary>
+        protected override bool WithVariablesInReturn => false;
     }
 }

--- a/Camunda.Api.Client/UserTask/CompleteTaskAndFetchVariables.cs
+++ b/Camunda.Api.Client/UserTask/CompleteTaskAndFetchVariables.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Camunda.Api.Client.UserTask
+﻿namespace Camunda.Api.Client.UserTask
 {
-    public class CompleteTaskAndFetchVariables: CompleteTaskBase
+    public class CompleteTaskAndFetchVariables : CompleteTaskBase
     {
         /// <summary>
         /// Variables will return after completing the task
         /// </summary>
-        public override bool WithVariablesInReturn { get; } = true;
+        protected override bool WithVariablesInReturn { get; } = true;
     }
 }

--- a/Camunda.Api.Client/UserTask/CompleteTaskAndFetchVariables.cs
+++ b/Camunda.Api.Client/UserTask/CompleteTaskAndFetchVariables.cs
@@ -5,6 +5,6 @@
         /// <summary>
         /// Variables will return after completing the task
         /// </summary>
-        protected override bool WithVariablesInReturn { get; } = true;
+        public override bool WithVariablesInReturn { get; } = true;
     }
 }

--- a/Camunda.Api.Client/UserTask/CompleteTaskAndFetchVariables.cs
+++ b/Camunda.Api.Client/UserTask/CompleteTaskAndFetchVariables.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Camunda.Api.Client.UserTask
+{
+    public class CompleteTaskAndFetchVariables: CompleteTaskBase
+    {
+        /// <summary>
+        /// Variables will return after completing the task
+        /// </summary>
+        public override bool WithVariablesInReturn { get; } = true;
+    }
+}

--- a/Camunda.Api.Client/UserTask/CompleteTaskBase.cs
+++ b/Camunda.Api.Client/UserTask/CompleteTaskBase.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Camunda.Api.Client.UserTask
+{
+    public abstract class CompleteTaskBase
+    {
+        /// <summary>
+        /// Variables will return after completing the task
+        /// </summary>
+        public abstract bool WithVariablesInReturn { get; }
+
+        /// <summary>
+        /// Object containing variable key-value pairs.
+        /// </summary>
+        public Dictionary<string, VariableValue> Variables = new Dictionary<string, VariableValue>();
+
+        public CompleteTaskBase SetVariable(string name, object value)
+        {
+          Variables = (Variables ?? new Dictionary<string, VariableValue>()).Set(name, value);
+          return this;
+        }
+    }
+}

--- a/Camunda.Api.Client/UserTask/CompleteTaskBase.cs
+++ b/Camunda.Api.Client/UserTask/CompleteTaskBase.cs
@@ -7,7 +7,7 @@ namespace Camunda.Api.Client.UserTask
         /// <summary>
         /// Variables will return after completing the task
         /// </summary>
-        protected abstract bool WithVariablesInReturn { get; }
+        public abstract bool WithVariablesInReturn { get; }
 
         /// <summary>
         /// Object containing variable key-value pairs.

--- a/Camunda.Api.Client/UserTask/CompleteTaskBase.cs
+++ b/Camunda.Api.Client/UserTask/CompleteTaskBase.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Camunda.Api.Client.UserTask
 {
@@ -9,7 +7,7 @@ namespace Camunda.Api.Client.UserTask
         /// <summary>
         /// Variables will return after completing the task
         /// </summary>
-        public abstract bool WithVariablesInReturn { get; }
+        protected abstract bool WithVariablesInReturn { get; }
 
         /// <summary>
         /// Object containing variable key-value pairs.
@@ -18,8 +16,8 @@ namespace Camunda.Api.Client.UserTask
 
         public CompleteTaskBase SetVariable(string name, object value)
         {
-          Variables = (Variables ?? new Dictionary<string, VariableValue>()).Set(name, value);
-          return this;
+            Variables = (Variables ?? new Dictionary<string, VariableValue>()).Set(name, value);
+            return this;
         }
     }
 }

--- a/Camunda.Api.Client/UserTask/IUserTaskRestService.cs
+++ b/Camunda.Api.Client/UserTask/IUserTaskRestService.cs
@@ -23,6 +23,9 @@ namespace Camunda.Api.Client.UserTask
         [Post("/task/{id}/complete")]
         Task CompleteTask(string id, [Body] CompleteTask completeTask);
 
+        [Post("/task/{id}/complete")]
+        Task<Dictionary<string, VariableValue>> CompleteTaskAndFetchVariables(string id, [Body] CompleteTaskAndFetchVariables completeTask);
+
         [Post("/task/{id}/resolve")]
         Task ResolveTask(string id, [Body] CompleteTask completeTask);
 

--- a/Camunda.Api.Client/UserTask/TaskResource.cs
+++ b/Camunda.Api.Client/UserTask/TaskResource.cs
@@ -66,6 +66,11 @@ namespace Camunda.Api.Client.UserTask
         public Task Complete(CompleteTask completeTask) => _api.CompleteTask(_taskId, completeTask);
 
         /// <summary>
+        /// Complete a task and update process variables. Returns current variables of the process instance.
+        /// </summary>
+        public Task<Dictionary<string, VariableValue>> CompleteAndFetchVariables(CompleteTaskAndFetchVariables completeTask) => _api.CompleteTaskAndFetchVariables(_taskId, completeTask);
+
+        /// <summary>
         /// Resolve a task and update execution variables.
         /// </summary>
         public Task Resolve(CompleteTask completeTask) => _api.ResolveTask(_taskId, completeTask);


### PR DESCRIPTION
Hi,

i have added a feature to receive all variables after completing a user task. So you need only one round trip to complete and fetch the variables.

This feature was introduced in version 7.11 of Camunda BPMN API (https://docs.camunda.org/manual/7.11/reference/rest/task/post-complete/).
Please review and commit

Thanks