### PR TITLE
Adding WithVariablesInReturn for user task complete

### DIFF
--- a/Camunda.Api.Client.sln
+++ b/Camunda.Api.Client.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2026
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29519.181
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Camunda.Api.Client", "Camunda.Api.Client\Camunda.Api.Client.csproj", "{647F2D5F-4B9C-4A36-AAB6-A787182B6083}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Camunda.Api.Client.Tests", "Camunda.Api.Client.Tests\Camunda.Api.Client.Tests.csproj", "{9EC88258-9A0B-448B-90F1-9FACA497228D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Camunda.Api.Client.Tests", "Camunda.Api.Client.Tests\Camunda.Api.Client.Tests.csproj", "{9EC88258-9A0B-448B-90F1-9FACA497228D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,7 +18,6 @@ Global
 		{647F2D5F-4B9C-4A36-AAB6-A787182B6083}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{647F2D5F-4B9C-4A36-AAB6-A787182B6083}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9EC88258-9A0B-448B-90F1-9FACA497228D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9EC88258-9A0B-448B-90F1-9FACA497228D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9EC88258-9A0B-448B-90F1-9FACA497228D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9EC88258-9A0B-448B-90F1-9FACA497228D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/Camunda.Api.Client/Camunda.Api.Client.csproj
+++ b/Camunda.Api.Client/Camunda.Api.Client.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>    
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.4.3</Version>
+    <Version>2.4.4.1</Version>
     <Product>Camunda REST API Client</Product>
     <Title>Camunda REST API Client</Title>
     <Authors>Jan Lucansky</Authors>

--- a/Camunda.Api.Client/Camunda.Api.Client.csproj
+++ b/Camunda.Api.Client/Camunda.Api.Client.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>    
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.4.4-withvariables-test-01</Version>
+    <Version>2.4.3</Version>
     <Product>Camunda REST API Client</Product>
     <Title>Camunda REST API Client</Title>
     <Authors>Jan Lucansky</Authors>

--- a/Camunda.Api.Client/Camunda.Api.Client.csproj
+++ b/Camunda.Api.Client/Camunda.Api.Client.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>    
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.4.4.1</Version>
+    <Version>2.4.4-withvariables-test-01</Version>
     <Product>Camunda REST API Client</Product>
     <Title>Camunda REST API Client</Title>
     <Authors>Jan Lucansky</Authors>

--- a/Camunda.Api.Client/UserTask/CompleteTask.cs
+++ b/Camunda.Api.Client/UserTask/CompleteTask.cs
@@ -2,16 +2,16 @@
 
 namespace Camunda.Api.Client.UserTask
 {
-    public class CompleteTask
+    public class CompleteTask : ResolveTask
     {
         /// <summary>
-        /// Object containing variable key-value pairs.
+        /// if set to true, API will return variables in response. Default behaviour is "false"
         /// </summary>
-        public Dictionary<string, VariableValue> Variables = new Dictionary<string, VariableValue>();
+        public bool? WithVariablesInReturn { get; set; } = null;
 
-        public CompleteTask SetVariable(string name, object value)
+        public new CompleteTask SetVariable(string name, object value)
         {
-            Variables = (Variables ?? new Dictionary<string, VariableValue>()).Set(name, value);
+            base.SetVariable(name, value);
             return this;
         }
     }

--- a/Camunda.Api.Client/UserTask/IUserTaskRestService.cs
+++ b/Camunda.Api.Client/UserTask/IUserTaskRestService.cs
@@ -24,7 +24,7 @@ namespace Camunda.Api.Client.UserTask
         Task CompleteTask(string id, [Body] CompleteTask completeTask);
 
         [Post("/task/{id}/resolve")]
-        Task ResolveTask(string id, [Body] CompleteTask completeTask);
+        Task ResolveTask(string id, [Body] ResolveTask resolveTask);
 
         [Post("/task/{id}/submit-form")]
         Task SubmitFormTask(string id, [Body] CompleteTask completeTask);

--- a/Camunda.Api.Client/UserTask/IUserTaskRestService.cs
+++ b/Camunda.Api.Client/UserTask/IUserTaskRestService.cs
@@ -23,11 +23,17 @@ namespace Camunda.Api.Client.UserTask
         [Post("/task/{id}/complete")]
         Task CompleteTask(string id, [Body] CompleteTask completeTask);
 
+        [Post("/task/{id}/complete")]
+        Task<Dictionary<string, VariableValue>> CompleteTaskAndFetchVariables(string id, [Body] CompleteTask completeTask);
+
         [Post("/task/{id}/resolve")]
         Task ResolveTask(string id, [Body] ResolveTask resolveTask);
 
         [Post("/task/{id}/submit-form")]
         Task SubmitFormTask(string id, [Body] CompleteTask completeTask);
+
+        [Post("/task/{id}/submit-form")]
+        Task<Dictionary<string, VariableValue>> SubmitFormTaskAndFetchVariables(string id, [Body] CompleteTask completeTask);
 
         [Get("/task/{id}/rendered-form")]
         Task<string> GetRenderedForm(string id);

--- a/Camunda.Api.Client/UserTask/ResolveTask.cs
+++ b/Camunda.Api.Client/UserTask/ResolveTask.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace Camunda.Api.Client.UserTask
+{
+    public class ResolveTask
+    {
+        /// <summary>
+        /// Object containing variable key-value pairs.
+        /// </summary>
+        public Dictionary<string, VariableValue> Variables = new Dictionary<string, VariableValue>();
+
+        public ResolveTask SetVariable(string name, object value)
+        {
+            Variables = (Variables ?? new Dictionary<string, VariableValue>()).Set(name, value);
+            return this;
+        }
+    }
+}

--- a/Camunda.Api.Client/UserTask/TaskResource.cs
+++ b/Camunda.Api.Client/UserTask/TaskResource.cs
@@ -43,6 +43,15 @@ namespace Camunda.Api.Client.UserTask
         public Task SubmitForm(CompleteTask completeTask) => _api.SubmitFormTask(_taskId, completeTask);
 
         /// <summary>
+        /// Complete a task and update process variables using a form submit, retrieving variables in response
+        /// </summary>
+        /// <remarks>
+        ///  * If the task is in state PENDING - ie. has been delegated before, it is not completed but resolved. Otherwise it will be completed.
+        ///  * If the task has Form Field Metadata defined, the process engine will perform backend validation for any form fields which have validators defined.
+        /// </remarks>
+        public Task<Dictionary<string, VariableValue>> SubmitFormAndFetchVariables(CompleteTask completeTask) => _api.SubmitFormTaskAndFetchVariables(_taskId, completeTask);
+
+        /// <summary>
         /// Retrieves the rendered form for a task. This method can be used for getting the HTML rendering of a Generated Task Form.
         /// </summary>
         public Task<string> GetRenderedForm() => _api.GetRenderedForm(_taskId);
@@ -64,6 +73,11 @@ namespace Camunda.Api.Client.UserTask
         /// Complete a task and update process variables.
         /// </summary>
         public Task Complete(CompleteTask completeTask) => _api.CompleteTask(_taskId, completeTask);
+
+        /// <summary>
+        /// Complete a task and update process variables, retrieving variables in response
+        /// </summary>
+        public Task<Dictionary<string, VariableValue>> CompleteAndFetchVariables(CompleteTask completeTask) => _api.CompleteTaskAndFetchVariables(_taskId, completeTask);
 
         /// <summary>
         /// Resolve a task and update execution variables.

--- a/Camunda.Api.Client/UserTask/TaskResource.cs
+++ b/Camunda.Api.Client/UserTask/TaskResource.cs
@@ -68,7 +68,7 @@ namespace Camunda.Api.Client.UserTask
         /// <summary>
         /// Resolve a task and update execution variables.
         /// </summary>
-        public Task Resolve(CompleteTask completeTask) => _api.ResolveTask(_taskId, completeTask);
+        public Task Resolve(ResolveTask resolveTask) => _api.ResolveTask(_taskId, resolveTask);
 
         /// <summary>
         /// Delegate a task to another user.


### PR DESCRIPTION
- introduced ResolveTask class for /task/{id}/resolve
- CompleteTask inherits from ResolveTask and implements WithVariablesInReturn
- additional methods: CompleteTaskAndFetchVariables and SubmitFormAndFetchVariables
- remarks:
-- in future versions ResolveTask and CompleteTask should not be compatible
-- in future versions the methods CompleteTaskAndFetchVariables and SubmitFormAndFetchVariables should be removed and CompleteTask and SubmitForm should return the deserialized response, even if null
-- ! when using CompleteTaskAndFetchVariables with WithVariablesInReturn == false or null, no variables will be returned in the response - same goes for SubmitFormAndFetchVariables