### PR TITLE
add variables filter to HistoricProcessInstanceQuery

### DIFF
--- a/Camunda.Api.Client/History/HistoricProcessInstanceQuery.cs
+++ b/Camunda.Api.Client/History/HistoricProcessInstanceQuery.cs
@@ -144,6 +144,11 @@ namespace Camunda.Api.Client.History
         /// </summary>
         [JsonProperty("activeActivityIdIn")]
         public List<string> ActiveActivityIds;
+        
+        /// <summary>
+        /// Array to only include process instances that have/had variables with certain values.
+        /// </summary>
+        public List<VariableQueryParameter> Variables = new List<VariableQueryParameter>();
     }
 
     public enum HistoricProcessInstanceQuerySorting


### PR DESCRIPTION
Reference:
https://docs.camunda.org/manual/7.9/reference/rest/history/process-instance/post-process-instance-query/

example query:
`{
  "processDefinitionKey": "process_test",
  "variables": [
    {
      "name": "someVariable",
      "operator": "eq",
      "value": "4564"
    }
  ],
  "finished": true
}`