### PR TITLE
#76 Added support for extension properties in external tasks

### DIFF
--- a/Camunda.Api.Client/ExternalTask/FetchExternalTaskTopic.cs
+++ b/Camunda.Api.Client/ExternalTask/FetchExternalTaskTopic.cs
@@ -82,6 +82,11 @@ namespace Camunda.Api.Client.ExternalTask
         /// </summary>
         public bool WithoutTenantId;
 
+        /// <summary>
+        /// Include extension properties define in BMPN activity.
+        /// </summary>
+        public bool IncludeExtensionProperties;
+
         public override string ToString() => TopicName;
     }
 }

--- a/Camunda.Api.Client/ExternalTask/LockedExternalTask.cs
+++ b/Camunda.Api.Client/ExternalTask/LockedExternalTask.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Camunda.Api.Client.ExternalTask
@@ -9,5 +8,10 @@ namespace Camunda.Api.Client.ExternalTask
         /// Object containing a property for each of the requested variables.
         /// </summary>
         public Dictionary<string, VariableValue> Variables;
+
+        /// <summary>
+        /// Object containing all extended properties from the BPMN for this task.
+        /// </summary>
+        public Dictionary<string, string> ExtensionProperties;
     }
 }


### PR DESCRIPTION
I have added support for extension properties for external tasks. This feature was introduced with camunda 7.14. It's required for our project.

https://docs.camunda.org/manual/7.14/reference/rest/external-task/fetch/#example-with-extension-properties