### PR TITLE
Added Version interface to package

### DIFF
--- a/Camunda.Api.Client.Tests/ProcessInstanceTests.cs
+++ b/Camunda.Api.Client.Tests/ProcessInstanceTests.cs
@@ -16,29 +16,14 @@ namespace Camunda.Api.Client.Tests
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.Expect(HttpMethod.Post, "http://localhost:8080/engine-rest")
-                .Respond(HttpStatusCode.OK, "text/html", "OK");
+            mockHttp.Expect(HttpMethod.Post, "http://localhost:8080/engine-rest/process-instance")
+                .Respond(HttpStatusCode.OK, "application/json", "[]");
 
 
             var client = CamundaClient.Create("http://localhost:8080/engine-rest", mockHttp);
             var process = await client.ProcessInstances.Query().List();
 
             Assert.NotNull(process);
-        }
-
-        [Fact]
-        public async Task GetVersion()
-        {
-            var mockHttp = new MockHttpMessageHandler();
-
-            mockHttp.Expect(HttpMethod.Get, "http://localhost:8080/engine-rest/version")
-                .Respond(HttpStatusCode.OK, "text/html", "{\"version\": \"7.14.0\"}");
-
-
-            var client = CamundaClient.Create("http://localhost:8080/engine-rest", mockHttp);
-            var version = await client.Version.Get();
-
-            Assert.Equal("7.14.0", version.Version);
         }
     }
 }

--- a/Camunda.Api.Client.Tests/ProcessInstanceTests.cs
+++ b/Camunda.Api.Client.Tests/ProcessInstanceTests.cs
@@ -25,5 +25,20 @@ namespace Camunda.Api.Client.Tests
 
             Assert.NotNull(process);
         }
+
+        [Fact]
+        public async Task GetVersion()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+
+            mockHttp.Expect(HttpMethod.Get, "http://localhost:8080/engine-rest/version")
+                .Respond(HttpStatusCode.OK, "text/html", "{\"version\": \"7.14.0\"}");
+
+
+            var client = CamundaClient.Create("http://localhost:8080/engine-rest", mockHttp);
+            var version = await client.Version.Get();
+
+            Assert.Equal("7.14.0", version.Version);
+        }
     }
 }

--- a/Camunda.Api.Client.Tests/VersionTests.cs
+++ b/Camunda.Api.Client.Tests/VersionTests.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using RichardSzalay.MockHttp;
+using Xunit;
+
+namespace Camunda.Api.Client.Tests
+{
+    public class VersionTests
+    {
+        [Fact]
+        public async Task GetVersion()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+
+            mockHttp.Expect(HttpMethod.Get, "http://localhost:8080/engine-rest/version")
+                .Respond(HttpStatusCode.OK, "application/json", "{\"version\": \"7.14.0\"}");
+
+
+            var client = CamundaClient.Create("http://localhost:8080/engine-rest", mockHttp);
+            var version = await client.Version.Get();
+
+            Assert.Equal("7.14.0", version.Version);
+        }
+    }
+}

--- a/Camunda.Api.Client/CamundaClient.cs
+++ b/Camunda.Api.Client/CamundaClient.cs
@@ -330,7 +330,7 @@ namespace Camunda.Api.Client
         /// <see href="https://docs.camunda.org/manual/7.9/reference/rest/filter/"/>
         public FilterService Filters => new FilterService(_filterApi.Value);
 
-        /// <see href="https://docs.camunda.org/manual/7.9/reference/rest/filter/"/>
+        /// <see href="https://docs.camunda.org/manual/7.9/reference/rest/version/"/>
         public VersionService Version => new VersionService(_versionApi.Value);
     }
 }

--- a/Camunda.Api.Client/CamundaClient.cs
+++ b/Camunda.Api.Client/CamundaClient.cs
@@ -30,6 +30,7 @@ using Camunda.Api.Client.VariableInstance;
 
 using JsonSerializer = Newtonsoft.Json.JsonSerializer;
 using Camunda.Api.Client.Filter;
+using Camunda.Api.Client.Version;
 
 namespace Camunda.Api.Client
 {
@@ -56,6 +57,7 @@ namespace Camunda.Api.Client
         private Lazy<IUserTaskRestService> _userTaskApi;
         private Lazy<IVariableInstanceRestService> _variableInstanceApi;
         private Lazy<IFilterRestService> _filterApi;
+        private Lazy<IVersionRestService> _versionApi;
 
         private HistoricApi _historicApi;
 
@@ -219,6 +221,7 @@ namespace Camunda.Api.Client
             _userTaskApi = CreateService<IUserTaskRestService>();
             _variableInstanceApi = CreateService<IVariableInstanceRestService>();
             _filterApi = CreateService<IFilterRestService>();
+            _versionApi = CreateService<IVersionRestService>();
 
             _historicApi = new HistoricApi()
             {
@@ -326,5 +329,8 @@ namespace Camunda.Api.Client
 
         /// <see href="https://docs.camunda.org/manual/7.9/reference/rest/filter/"/>
         public FilterService Filters => new FilterService(_filterApi.Value);
+
+        /// <see href="https://docs.camunda.org/manual/7.9/reference/rest/filter/"/>
+        public VersionService Version => new VersionService(_versionApi.Value);
     }
 }

--- a/Camunda.Api.Client/Version/IVersionRestService.cs
+++ b/Camunda.Api.Client/Version/IVersionRestService.cs
@@ -1,0 +1,11 @@
+﻿using Refit;
+using System.Threading.Tasks;
+
+namespace Camunda.Api.Client.Version
+{
+    internal interface IVersionRestService
+    {
+        [Get("/version")]
+        Task<VersionInfo> Get();
+    }
+}

--- a/Camunda.Api.Client/Version/VersionInfo.cs
+++ b/Camunda.Api.Client/Version/VersionInfo.cs
@@ -1,0 +1,10 @@
+﻿namespace Camunda.Api.Client.Version
+{
+    public class VersionInfo
+    {
+        /// <summary>
+        /// The version of the camunda engine.
+        /// </summary>
+        public string Version;
+    }
+}

--- a/Camunda.Api.Client/Version/VersionService.cs
+++ b/Camunda.Api.Client/Version/VersionService.cs
@@ -1,0 +1,15 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+
+namespace Camunda.Api.Client.Version
+{
+    public class VersionService
+    {
+        private IVersionRestService _api;
+
+        internal VersionService(IVersionRestService api) { _api = api; }
+
+        public Task<VersionInfo> Get() =>
+            _api.Get();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Each part listed below is fully covered according to https://docs.camunda.org/ma
 - [x] [Tenant](https://docs.camunda.org/manual/latest/reference/rest/tenant/)
 - [x] [User](https://docs.camunda.org/manual/latest/reference/rest/user/)
 - [x] [Variable Instance](https://docs.camunda.org/manual/latest/reference/rest/variable-instance/)
+- [x] [Version](https://docs.camunda.org/manual/latest/reference/rest/version/)
 
 ## Install
 The Camunda REST API Client is available on [nuget.org](https://www.nuget.org/packages/Camunda.Api.Client)


### PR DESCRIPTION
I added the Version interface to the package.

- The version of the Camunda engine can be retrieved easily
- Can be used for health checks
